### PR TITLE
Removed "bower install" step

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ First, ensure you have the following installed:
 Then, install dependencies and run the preview server:
 
 ```bash
-$ npm install && bower install
+$ npm install
 $ gulp serve
 ```


### PR DESCRIPTION
You don't need to run `bower install` because it's part of your `postinstall` script in `package.json`. :balloon: 
